### PR TITLE
Add 'authentication' value validation

### DIFF
--- a/githubcloner.py
+++ b/githubcloner.py
@@ -23,6 +23,7 @@ import requests
 import threading
 import time
 
+
 class getReposURLs(object):
     def __init__(self):
         self.user_agent = "GithubCloner (https://github.com/mazen160/GithubCloner)"
@@ -381,6 +382,11 @@ def main():
 
     if not os.path.exists(output_path):
         os.mkdir(output_path)
+
+    if ':' not in authentication:
+        print('Incorrect authentication value, must be: <username>:<personal_access_token>')
+        print('\nExiting...')
+        exit(1)
 
     if authentication is not None:
         if getReposURLs().checkAuthencation(authentication.split(":")[0], authentication.split(":")[1]) is False:

--- a/githubcloner.py
+++ b/githubcloner.py
@@ -383,12 +383,11 @@ def main():
     if not os.path.exists(output_path):
         os.mkdir(output_path)
 
-    if ':' not in authentication:
-        print('Incorrect authentication value, must be: <username>:<personal_access_token>')
-        print('\nExiting...')
-        exit(1)
-
     if authentication is not None:
+        if ':' not in authentication:
+            print('[!] Error: Incorrect authentication value, must be: <username>:<password_or_personal_access_token>')
+            print('\nExiting...')
+            exit(1)
         if getReposURLs().checkAuthencation(authentication.split(":")[0], authentication.split(":")[1]) is False:
             print("Error: authentication failed.")
             print("\nExiting...")


### PR DESCRIPTION
- Add 'authentication' value validation.
- 2 blank lines before class (PEP8)

I discovered this omission when I thought that the personal access token was all that was required:

```
$ githubcloner.py --org example_org -o outdir --include-authenticated-repos --authentication REDACTED_ACCESS_TOKEN
Traceback (most recent call last):
  File "githubcloner.py", line 434, in <module>
    main()
  File "githubcloner.py", line 386, in main
    if getReposURLs().checkAuthencation(authentication.split(":")[0], authentication.split(":")[1]) is False:
IndexError: list index out of range
```