### PR TITLE
Fix folder names

### DIFF
--- a/githubcloner.py
+++ b/githubcloner.py
@@ -264,7 +264,8 @@ def cloneRepo(URL, cloningpath, username=None, token=None):
         if (username or token) is not None:
             URL = URL.replace("https://", "https://{}:{}@".format(username, token))
         repopath = URL.split("/")[-2] + "_" + URL.split("/")[-1]
-        repopath = repopath.rstrip(".git")
+        if repopath.endswith(".git"):
+            repopath = repopath[:-4]
         if '@' in repopath:
             repopath = repopath.replace(repopath[:repopath.index("@") + 1], "")
         fullpath = cloningpath + "/" + repopath


### PR DESCRIPTION
The folder name was sometimes missing a few characters at the end due to
a misinterpretation of the str.rstrip() method. The intention was to
remove the trailing string ".git", gut the old code was removing all
occurrences of the characters ".", "g", "i" and "t" at the end of the
folder name. Replaced that part of the code with an explicit test using
str.endswith().