### PR TITLE
Add check for 'API rate limit exceeded'

### DIFF
--- a/githubcloner.py
+++ b/githubcloner.py
@@ -154,6 +154,14 @@ class getReposURLs(object):
             except TypeError:
                 pass
 
+            try:
+                if "API rate limit exceeded" in resp["message"]:
+                    print('[!] Error: Github API rate limit exceeded')
+                    print('\nExiting...')
+                    exit(1)
+            except TypeError:
+                pass
+
             for i in range(len(resp)):
                 URLs.append(resp[i]["git_url"])
             current_page += 1


### PR DESCRIPTION
I hit the API rate limit while testing the rstrip bug.

```
(Pdb) resp
{'message': "API rate limit exceeded for 209.249.94.114. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)", 'documentation_url': 'https://developer.github.com/v3/#rate-limiting'}
```